### PR TITLE
feat(regex): add DD/MM/YYYY date regex with optional separators

### DIFF
--- a/src/model/regexPatterns.js
+++ b/src/model/regexPatterns.js
@@ -200,6 +200,55 @@ export const generatePhoneBRRegex = (options = {}) => {
     return { pattern, flags };
 };
 
+// --- CATEGORIA 8: DATE (DD/MM/YYYY) ---
+
+/**
+ * Gera um padrão de Regex para validação de data no formato DD/MM/YYYY.
+ * @param {Object} options - Critérios de customização
+ * @param {boolean} options.allowDash - Permitir "-" como separador
+ * @param {boolean} options.allowNoSeparator - Permitir data sem separador ex: DDMMYYYY
+ * @returns {{pattern: string, flags: string}}
+ */
+
+export const generateDateBRRegex = (options = {}) => {
+  const { allowDash = false, allowNoSeparator = false } = options;
+
+  // Dia: 01–31
+  const day = "(0[1-9]|[12][0-9]|3[01])";
+
+  // Mês: 01–12
+  const month = "(0[1-9]|1[0-2])";
+
+  // Ano: 4 dígitos
+  const year = "(\\d{4})";
+
+  // Default: DD/MM/YYYY
+  let separator = "\\/";
+
+  // If allowDash => allow "/" or "-"
+  if (allowDash) {
+    separator = "[\\/-]";
+  }
+
+  // Main pattern
+  let pattern = `${day}${separator}${month}${separator}${year}`;
+
+  // Optionally support DDMMYYYY (no separators)
+  if (allowNoSeparator) {
+    pattern = `(${pattern}|${day}${month}${year})`;
+  }
+
+  pattern = `^${pattern}$`;
+
+  return { pattern, flags: "" };
+};
+
+
+
+
+
+
+
 // --- ESTRUTURA PARA NOVAS CONTRIBUIÇÕES ---
 
 /**
@@ -287,6 +336,24 @@ export const RegexCategories = {
         id: 'allowCIDR',
         labels: { pt: 'Permitir sufixo CIDR (ex: /24)', en: 'Allow CIDR suffix (e.g. /24)' },
         type: 'checkbox',
+        default: false,
+      },
+    ],
+  },
+  datebr: {
+    name: { pt: "Data (DD/MM/YYYY)", en: "Date (DD/MM/YYYY)" },
+    generator: generateDateBRRegex,
+    criteria: [
+      {
+        id: "allowDash",
+        labels: { pt: 'Permitir hífen (ex: 31-12-2025)', en: 'Allow dash (ex: 31-12-2025)' },
+        type: "checkbox",
+        default: false,
+      },
+      {
+        id: "allowNoSeparator",
+        labels: { pt: 'Permitir sem separador (ex: 31122025)', en: 'Allow no separator (ex: 31122025)' },
+        type: "checkbox",
         default: false,
       },
     ],


### PR DESCRIPTION
 **Related Issue**
  Fixes #38 

**Type of Change**
 ✨ Feature

**Summary**
This PR adds support for generating regex patterns to validate dates in the DD/MM/YYYY format.
It expands the available regex catalog and enables users to validate common Brazilian and similar regional date formats.

**Details**
Added new generator function: generateDateBRRegex

**Supports:**
- Standard slash format: DD/MM/YYYY
- Optional: DD-MM-YYYY
- Optional: No separator (DDMMYYYY)
- Updated RegexCategories to register new pattern

**Added toggle criteria for:**
- allowDash
- allowNoSeparator



@priscillatrevizan, If everything looks good, kindly review and merge this PR.
Please let me know if any changes or improvements are needed.

